### PR TITLE
Add a default shed_tool_conf.xml that explicitly sets tool_path="/export/galaxy/database/shed_tools".

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ COPY config/gaiac.yml /etc/galaxy/tools.yml
 COPY gravity.yml /etc/galaxy/gravity.yml
 COPY install_tools_wrapper.sh /usr/bin/install-tools
 
+COPY config/shed_tool_conf.xml /export/galaxy/database/config/shed_tool_conf.xml
+ENV GALAXY_CONFIG_SHED_TOOL_CONFIG_FILE="/export/galaxy/database/config/shed_tool_conf.xml"
+RUN chown -R galaxy:galaxy /export/galaxy
+
 RUN chmod +x /usr/bin/install-tools
 RUN install-tools  /etc/galaxy/tools.yml
 

--- a/config/shed_tool_conf.xml
+++ b/config/shed_tool_conf.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" ?>
+<toolbox tool_path="/export/galaxy/database/shed_tools">
+</toolbox>


### PR DESCRIPTION
Fixes tools not being available when image is run as container.